### PR TITLE
Minor changes on cybre-light theme

### DIFF
--- a/app/javascript/styles/cybre-light.scss
+++ b/app/javascript/styles/cybre-light.scss
@@ -19,7 +19,7 @@ $about-page-text: $primary-text-color;
 
 @import 'cybre-base';
 
-$gold-star: #dd9d08;
+$gold-star: $ui-highlight-color;
 
 /* cybre-specific additions */
 
@@ -266,6 +266,29 @@ $gold-star: #dd9d08;
 
 .status-card, .status-card.compact {
   border-color: $ui-highlight-color;
+}
+
+.search__input {
+  border: 1px solid $ui-primary-color;
+  border-radius: 10px;
+}
+
+.icon-with-badge {
+  &__badge {
+    background: $ui-base-color;
+    border: 2px solid lighten($ui-highlight-color, 30%);
+    color: $dark-text-color;
+  }
+}
+
+.relationship-tag {
+  color: $primary-text-color;
+  background-color: $ui-base-color;
+}
+
+.media-modal__nav {
+  background: rgba($ui-primary-color, 0.5);
+  color: $ui-base-color;
 }
 
 // selectivity -- needs to override .column-header > button
@@ -652,6 +675,9 @@ button.icon-button {
 
 .reply-indicator__content a {
   color: lighten($ui-highlight-color, 30%);
+  &.unhandled-link {
+    color:lighten( #ff0051, 30%);
+  }
 }
 
 .status__content
@@ -664,7 +690,12 @@ button.icon-button {
         color: darken($ui-base-color, 40%);
       }
     }
+
+    &.unhandled-link {
+      color: #ff0051;
+    }
   }
+
 }
 
 .detailed-status__display-name {
@@ -764,8 +795,8 @@ button.icon-button {
 
   .sidebar {
     .logo {
-      -webkit-filter: invert(100%);
-      filter: invert(100%);
+      -webkit-filter: hue-rotate(133deg) saturate(70%) brightness(110%);
+      filter: hue-rotate(133deg) saturate(70%) brightness(110%);
     }
 
     ul {


### PR DESCRIPTION
1. 更改“喜欢”图标点亮后的颜色与“转嘟”点亮后一致；
2. 外链接使用更加鲜艳的颜色；
3. 搜索栏增加圆角边框；
4. 更改消息数字提示的底色和数字颜色；
5. 被关注者主页“关注了你”底色改为浅色；
6. 浏览多图时，两侧箭头改为浅色；
7. 更改首选项页面的Mastodon logo为粉白色。